### PR TITLE
Adds the ability to add offset to background position

### DIFF
--- a/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_background_image
     - field.field.paragraph.xeno_hero.xeno_content
     - field.field.paragraph.xeno_hero.xeno_invert
@@ -18,6 +19,14 @@ targetEntityType: paragraph
 bundle: xeno_hero
 mode: default
 content:
+  xeno_offset:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   xeno_background_image:
     weight: 0
     settings:

--- a/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_background_image
     - field.field.paragraph.xeno_hero.xeno_content
     - field.field.paragraph.xeno_hero.xeno_invert
+    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_overlay
     - field.field.paragraph.xeno_hero.xeno_parallax
     - field.field.paragraph.xeno_hero.xeno_zoom

--- a/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_form_display.paragraph.xeno_hero.default.yml
@@ -19,14 +19,6 @@ targetEntityType: paragraph
 bundle: xeno_hero
 mode: default
 content:
-  xeno_offset:
-    weight: 7
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   xeno_background_image:
     weight: 0
     settings:
@@ -50,6 +42,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+  xeno_offset:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
   xeno_overlay:
     weight: 3
     settings: {  }

--- a/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_background_image
     - field.field.paragraph.xeno_hero.xeno_content
     - field.field.paragraph.xeno_hero.xeno_invert
@@ -17,6 +18,14 @@ targetEntityType: paragraph
 bundle: xeno_hero
 mode: default
 content:
+  xeno_offset:
+    weight: 6
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   xeno_background_image:
     weight: 0
     label: hidden

--- a/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
@@ -2,10 +2,10 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_background_image
     - field.field.paragraph.xeno_hero.xeno_content
     - field.field.paragraph.xeno_hero.xeno_invert
+    - field.field.paragraph.xeno_hero.xeno_offset
     - field.field.paragraph.xeno_hero.xeno_overlay
     - field.field.paragraph.xeno_hero.xeno_parallax
     - paragraphs.paragraphs_type.xeno_hero

--- a/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
+++ b/config/install/core.entity_view_display.paragraph.xeno_hero.default.yml
@@ -18,14 +18,6 @@ targetEntityType: paragraph
 bundle: xeno_hero
 mode: default
 content:
-  xeno_offset:
-    weight: 6
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
   xeno_background_image:
     weight: 0
     label: hidden
@@ -48,6 +40,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: list_key
+  xeno_offset:
+    weight: 6
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
   xeno_overlay:
     weight: 3
     label: hidden

--- a/config/install/field.field.paragraph.xeno_hero.xeno_offset.yml
+++ b/config/install/field.field.paragraph.xeno_hero.xeno_offset.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.xeno_offset
+    - paragraphs.paragraphs_type.xeno_hero
+id: paragraph.xeno_hero.field_offset
+field_name: xeno_offset
+entity_type: paragraph
+bundle: xeno_hero
+label: Offset
+description: 'Enter a positive number to modify the position of the background image.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/install/field.storage.paragraph.xeno_offset.yml
+++ b/config/install/field.storage.paragraph.xeno_offset.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.xeno_offset
+field_name: xeno_offset
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/js/xeno-hero.js
+++ b/js/xeno-hero.js
@@ -26,9 +26,16 @@
       $fwindow.on('scroll resize', function() {
         var docViewTop = $(window).scrollTop();
         var docViewBottom = docViewTop + $(window).height();
+        var offset = $backgroundObj.parent().attr('data-offset');
+        if (offset === undefined) {
+          offset = 0;
+        }
+        else {
+          offset = parseInt(offset);
+        }
 
         if ($backgroundObj.offset().top < docViewBottom) {
-          yPos = + ((docViewBottom - $backgroundObj.offset().top - $backgroundObj.height()*1.25) / speed);
+          yPos = -((docViewTop / speed) + offset);
           coords = '50% '+ yPos + 'px';
 
           $backgroundObj.css({ backgroundPosition: coords });

--- a/templates/paragraph--xeno-hero.html.twig
+++ b/templates/paragraph--xeno-hero.html.twig
@@ -88,6 +88,12 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
   %}
 {% endif %}
 
+{# Renders Parallax Offset field. #}
+{# Sets data attibute value from user input. #}
+{% if content.xeno_offset|render %}
+  {% set parallax_offset = content.xeno_offset['#items'].getString() %}
+{% endif %}
+
 {# Renders Invert field. #}
 {# Sets class from values in database. #}
 {% if content.xeno_invert|render %}
@@ -126,11 +132,11 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
 {% endif %}
 
 {# Prints div with classes, & content w/o img/invert/overlay/parallax fields. #}
-<div{{ attributes.addClass(classes).setAttribute('data-overlay', overlay_levels).setAttribute('data-speed', parallax_speeds).setAttribute('data-offset', content.xeno_offset['#items'].getString()) }}>
+<div{{ attributes.addClass(classes).setAttribute('data-overlay', overlay_levels).setAttribute('data-speed', parallax_speeds).setAttribute('data-offset', parallax_offset) }}>
   {% if content.xeno_background_image|render %}
     <div class="paragraph--type--xeno-hero__image">
       {{ content.xeno_background_image }}
     </div>
   {% endif %}
-  {{ content|without('xeno_background_image', 'xeno_invert', 'xeno_overlay', 'xeno_parallax') }}
+  {{ content|without('xeno_background_image', 'xeno_invert', 'xeno_offset', 'xeno_overlay', 'xeno_parallax') }}
 </div>

--- a/templates/paragraph--xeno-hero.html.twig
+++ b/templates/paragraph--xeno-hero.html.twig
@@ -126,7 +126,7 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
 {% endif %}
 
 {# Prints div with classes, & content w/o img/invert/overlay/parallax fields. #}
-<div{{ attributes.addClass(classes).setAttribute('data-overlay', overlay_levels).setAttribute('data-speed', parallax_speeds) }}>
+<div{{ attributes.addClass(classes).setAttribute('data-overlay', overlay_levels).setAttribute('data-speed', parallax_speeds).setAttribute('data-offset', content.xeno_offset['#items'].getString()) }}>
   {% if content.xeno_background_image|render %}
     <div class="paragraph--type--xeno-hero__image">
       {{ content.xeno_background_image }}

--- a/xeno_hero.install
+++ b/xeno_hero.install
@@ -28,6 +28,6 @@ function xeno_hero_update_8001() {
   }
 
   // Send message to updater.
-  $message = t('Offset field added to the hero bundle. It allows you to modify the position of the background image. Navigate to the Manager form display and Manage display for Hero to enable the offset field.');
+  $message = t('Offset field added to the hero bundle. It allows you to modify the position of the background image. Navigate to the Manage form display and Manage display for Hero to enable the offset field.');
   return $message;
 }

--- a/xeno_hero.install
+++ b/xeno_hero.install
@@ -10,19 +10,6 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 
 /**
- * Overrides configuration.
- *
- * @param string $config_name
- *   Configuration name.
- * @param string $path
- *   Base path.
- */
-function xeno_hero_override_config($config_name, $path) {
-  $active_storage = \Drupal::service('config.storage');
-  $active_storage->write($config_name, Yaml::parse(file_get_contents($path . '/config/install/' . $config_name . '.yml')));
-}
-
-/**
  * Adds offset field to Hero paragraph.
  */
 function xeno_hero_update_8001() {
@@ -40,12 +27,7 @@ function xeno_hero_update_8001() {
     FieldConfig::create($field_yml)->save();
   }
 
-  // Create Paragraphs bundle form.
-  xeno_hero_override_config('core.entity_form_display.paragraph.xeno_hero.default', $path);
-  // Create Paragraphs bundle view.
-  xeno_hero_override_config('core.entity_view_display.paragraph.xeno_hero.default', $path);
-
   // Send message to updater.
-  $message = t('Offset field added to the hero bundle. It allows you to modify the position of the background image.');
+  $message = t('Offset field added to the hero bundle. It allows you to modify the position of the background image. Navigate to the Manager form display and Manage display for Hero to enable the offset field.');
   return $message;
 }

--- a/xeno_hero.install
+++ b/xeno_hero.install
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Install / Update functions for Xeno Hero.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Overrides configuration.
+ *
+ * @param string $config_name
+ *   Configuration name.
+ * @param string $path
+ *   Base path.
+ */
+function xeno_hero_override_config($config_name, $path) {
+  $active_storage = \Drupal::service('config.storage');
+  $active_storage->write($config_name, Yaml::parse(file_get_contents($path . '/config/install/' . $config_name . '.yml')));
+}
+
+/**
+ * Adds offset field to Hero paragraph.
+ */
+function xeno_hero_update_8001() {
+  // Sets variable for the path.
+  $path = drupal_get_path('module', 'xeno_hero');
+
+  // Create field storage.
+  $field_storage_yml = Yaml::parse(file_get_contents($path . '/config/install/field.storage.paragraph.xeno_offset.yml'));
+  if (!FieldStorageConfig::loadByName($field_storage_yml['entity_type'], $field_storage_yml['field_name'])) {
+    FieldStorageConfig::create($field_storage_yml)->save();
+  }
+  // Create field instance.
+  $field_yml = Yaml::parse(file_get_contents($path . '/config/install/field.field.paragraph.xeno_hero.xeno_offset.yml'));
+  if (!FieldConfig::loadByName($field_yml['entity_type'], $field_yml['bundle'], $field_yml['field_name'])) {
+    FieldConfig::create($field_yml)->save();
+  }
+
+  // Create Paragraphs bundle form.
+  xeno_hero_override_config('core.entity_form_display.paragraph.xeno_hero.default', $path);
+  // Create Paragraphs bundle view.
+  xeno_hero_override_config('core.entity_view_display.paragraph.xeno_hero.default', $path);
+
+  // Send message to updater.
+  $message = t('Offset field added to the hero bundle. It allows you to modify the position of the background image.');
+  return $message;
+}


### PR DESCRIPTION
Ran into some issues with the background image.  I would see a black area above the image.  

I used the same formula found [here](https://code.tutsplus.com/tutorials/a-simple-parallax-scrolling-technique--net-27641) and it seems to work better:

```
var yPos = -($window.scrollTop() / $bgobj.data('speed'));
```

Not sure if it was just me but that worked a lot better. 


Also, needed the ability to add a little offset so the image displays in the position I would like it to show.  I added an offset field that lets you control it.

