### PR TITLE
drupal is a dependency

### DIFF
--- a/xeno_hero.libraries.yml
+++ b/xeno_hero.libraries.yml
@@ -8,3 +8,4 @@ xeno-hero:
       minified: false
   dependencies:
     - core/jquery
+    - core/drupal


### PR DESCRIPTION
As an anonymous user the drupal library was not loaded by default, when I did not have drupal as a dependency in my theme library js.